### PR TITLE
Improve ponyfill perf

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,18 @@
+# Ponyfill benchmarks
+
+Run the benchmark suite on an otherwise idle machine:
+
+```sh
+npm run benchmark
+```
+
+To compare a change, save the baseline and pass it back after making the change:
+
+```sh
+npm run benchmark -- --json > /tmp/composite-baseline.json
+npm run benchmark -- --compare /tmp/composite-baseline.json
+```
+
+Each case warms up independently, calibrates toward 120 ms per sample, and reports the median and range of seven
+samples. Compare runs with the same Node version and machine. Cache-miss results include allocation, registry growth,
+and garbage-collection costs, so their range is normally wider than cache-hit results.

--- a/benchmarks/ponyfill.ts
+++ b/benchmarks/ponyfill.ts
@@ -1,0 +1,110 @@
+import { performance } from "node:perf_hooks";
+import { readFileSync } from "node:fs";
+import { Composite } from "../polyfill/index.ts";
+
+const SAMPLE_COUNT = 7;
+const SAMPLE_TIME_MS = 120;
+const WARMUP_TIME_MS = 100;
+
+type Benchmark = {
+    name: string;
+    operation: () => void;
+};
+
+type Result = {
+    name: string;
+    iterations: number;
+    medianOpsPerSecond: number;
+    minOpsPerSecond: number;
+    maxOpsPerSecond: number;
+};
+
+let sink: unknown;
+const small = { x: 1, y: 2 };
+const wide = Object.fromEntries(Array.from({ length: 20 }, (_, i) => [`key${i.toString().padStart(2, "0")}`, i]));
+const nested = Composite({ child: Composite({ x: 1, y: 2 }), tag: "point" });
+const nestedInput = { child: Composite({ x: 1, y: 2 }), tag: "point" };
+const longStringInput = { value: "x".repeat(16 * 1024) };
+
+let unique = 0;
+const benchmarks: Benchmark[] = [
+    { name: "Composite cache hit (2 keys)", operation: () => void (sink = Composite(small)) },
+    { name: "Composite cache hit (20 keys)", operation: () => void (sink = Composite(wide)) },
+    { name: "Composite nested cache hit", operation: () => void (sink = Composite(nestedInput)) },
+    { name: "Composite cache miss (unique number)", operation: () => void (sink = Composite({ value: unique++ })) },
+    { name: "Composite cache hit (16 KiB string)", operation: () => void (sink = Composite(longStringInput)) },
+];
+
+function runFor(operation: () => void, iterations: number): number {
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) operation();
+    return performance.now() - start;
+}
+
+function calibrate(operation: () => void): number {
+    let iterations = 1;
+    while (iterations < 2 ** 30) {
+        const duration = runFor(operation, iterations);
+        if (duration >= WARMUP_TIME_MS) {
+            return Math.max(1, Math.round((iterations * SAMPLE_TIME_MS) / duration));
+        }
+        iterations *= 2;
+    }
+    return iterations;
+}
+
+function median(values: number[]): number {
+    const sorted = values.toSorted((a, b) => a - b);
+    return sorted[Math.floor(sorted.length / 2)];
+}
+
+function benchmark({ name, operation }: Benchmark): Result {
+    const iterations = calibrate(operation);
+    runFor(operation, iterations);
+    const samples = Array.from({ length: SAMPLE_COUNT }, () => {
+        const duration = runFor(operation, iterations);
+        return (iterations * 1000) / duration;
+    });
+    return {
+        name,
+        iterations,
+        medianOpsPerSecond: median(samples),
+        minOpsPerSecond: Math.min(...samples),
+        maxOpsPerSecond: Math.max(...samples),
+    };
+}
+
+const results = benchmarks.map(benchmark);
+const compareIndex = process.argv.indexOf("--compare");
+if (compareIndex !== -1) {
+    const baselinePath = process.argv[compareIndex + 1];
+    if (baselinePath === undefined) throw new TypeError("--compare requires a baseline JSON path");
+    const baseline = JSON.parse(readFileSync(baselinePath, "utf8")) as { results: Result[] };
+    const baselineByName = new Map(baseline.results.map((result) => [result.name, result]));
+    console.table(
+        results.map(({ name, medianOpsPerSecond }) => {
+            const baselineOpsPerSecond = baselineByName.get(name)?.medianOpsPerSecond;
+            return {
+                benchmark: name,
+                "baseline ops/s": baselineOpsPerSecond && Math.round(baselineOpsPerSecond).toLocaleString("en-US"),
+                "current ops/s": Math.round(medianOpsPerSecond).toLocaleString("en-US"),
+                change:
+                    baselineOpsPerSecond && `${((medianOpsPerSecond / baselineOpsPerSecond - 1) * 100).toFixed(1)}%`,
+            };
+        }),
+    );
+} else if (process.argv.includes("--json")) {
+    console.log(JSON.stringify({ node: process.version, results }, null, 2));
+} else {
+    console.table(
+        results.map(({ name, medianOpsPerSecond, minOpsPerSecond, maxOpsPerSecond }) => ({
+            benchmark: name,
+            "median ops/s": Math.round(medianOpsPerSecond).toLocaleString("en-US"),
+            "min ops/s": Math.round(minOpsPerSecond).toLocaleString("en-US"),
+            "max ops/s": Math.round(maxOpsPerSecond).toLocaleString("en-US"),
+        })),
+    );
+}
+
+// Keep benchmark results observable to the optimizer.
+void sink;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "test": "node --test --experimental-strip-types",
+        "benchmark": "node --experimental-strip-types benchmarks/ponyfill.ts",
         "build-polyfill": "npx --yes esbuild@0.25.9 ./polyfill/index.ts --bundle --global-name=compositePolyfill --outfile=./polyfill/composite.js --drop-labels=DEV",
         "format": "prettier --write .",
         "start": "npm run build-loose -- --watch",

--- a/polyfill/composite.ts
+++ b/polyfill/composite.ts
@@ -1,4 +1,3 @@
-import { assert } from "./internal/utils.ts";
 import { ownKeys, apply, freeze, sort, NaN, getOwnPropertyDescriptor, is } from "./internal/originals.ts";
 import { __Composite__, objectIsComposite, setHash } from "./internal/composite-class.ts";
 import { MurmurHashStream } from "./internal/murmur.ts";
@@ -7,7 +6,15 @@ import { SafeMap, SafeWeakRef } from "./internal/safe.ts";
 
 export type Composite = __Composite__;
 
-const composites = new SafeMap<number, Array<SafeWeakRef<Composite>>>();
+class CompositeRef extends SafeWeakRef<Composite> {
+    readonly size: number;
+    constructor(value: Composite, size: number) {
+        super(value);
+        this.size = size;
+    }
+}
+
+const composites = new SafeMap<number, Array<CompositeRef>>();
 const fr = new FinalizationRegistry((hash: number) => {
     let bucket = composites.safeGet(hash);
     if (bucket) {
@@ -29,13 +36,6 @@ const fr = new FinalizationRegistry((hash: number) => {
     }
 });
 const register = fr.register.bind(fr);
-
-function isStringArray(a: unknown[]): a is string[] {
-    for (let i = 0; i < a.length; i++) {
-        if (typeof a[i] !== "string") return false;
-    }
-    return true;
-}
 
 type Entry = { readonly k: string; readonly v: unknown };
 
@@ -93,9 +93,10 @@ export function Composite(arg: object, options?: CompositeOptions): Composite {
     let emptyIndex = -1;
     if (cs) {
         for (let i = 0; i < cs.length; i++) {
-            let ref = cs[i]?.safeDeref();
+            const compositeRef = cs[i];
+            let ref = compositeRef?.safeDeref();
             if (ref !== void 0) {
-                if (compositeMatchesEntries(ref, entries)) {
+                if (compositeRef.size === entries.length && compositeMatchesEntries(ref, entries)) {
                     return ref;
                 }
             } else if (emptyIndex === -1) {
@@ -110,12 +111,12 @@ export function Composite(arg: object, options?: CompositeOptions): Composite {
     }
 
     if (!cs) {
-        cs = [new SafeWeakRef(c)];
+        cs = [new CompositeRef(c, entries.length)];
         composites.safeSet(hash, cs);
     } else if (emptyIndex === -1) {
-        cs[cs.length] = new SafeWeakRef(c);
+        cs[cs.length] = new CompositeRef(c, entries.length);
     } else {
-        cs[emptyIndex] = new SafeWeakRef(c);
+        cs[emptyIndex] = new CompositeRef(c, entries.length);
     }
 
     register(c, hash);
@@ -130,11 +131,6 @@ export function isComposite(arg: unknown): arg is Composite {
 Composite.isComposite = isComposite;
 
 function compositeMatchesEntries(a: Composite, entries: readonly Entry[]): boolean {
-    const aKeys = ownKeys(a);
-    DEV: assert(isStringArray(aKeys));
-    if (aKeys.length !== entries.length) {
-        return false;
-    }
     for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
         if (!(entry.k in a) || !is((a as any)[entry.k], entry.v)) return false;

--- a/polyfill/composite.ts
+++ b/polyfill/composite.ts
@@ -79,7 +79,6 @@ export function Composite(arg: object, options?: CompositeOptions): Composite {
 
     apply(sort, entries, [byKey]);
 
-    const c = new __Composite__();
     const hasher = new MurmurHashStream();
     for (let i = 0; i < entries.length; i++) {
         const k = entries[i].k;
@@ -87,34 +86,36 @@ export function Composite(arg: object, options?: CompositeOptions): Composite {
         hasher.update(KEY);
         hasher.update(k);
         updateHasher(hasher, v);
-        (c as any)[k] = v;
     }
 
     let hash = hasher.digest();
     let cs = composites.safeGet(hash);
-    if (!cs) {
-        cs = [new SafeWeakRef(c)];
-        composites.safeSet(hash, cs);
-    } else {
-        let emptyIndex = -1;
-        let compKeys;
+    let emptyIndex = -1;
+    if (cs) {
         for (let i = 0; i < cs.length; i++) {
             let ref = cs[i]?.safeDeref();
             if (ref !== void 0) {
-                compKeys ??= ownKeys(c);
-                DEV: assert(isStringArray(compKeys));
-                if (compositesStructurallyEqual(ref, c, compKeys)) {
+                if (compositeMatchesEntries(ref, entries)) {
                     return ref;
                 }
             } else if (emptyIndex === -1) {
                 emptyIndex = i;
             }
         }
-        if (emptyIndex === -1) {
-            cs[cs.length] = new SafeWeakRef(c);
-        } else {
-            cs[emptyIndex] = new SafeWeakRef(c);
-        }
+    }
+
+    const c = new __Composite__();
+    for (let i = 0; i < entries.length; i++) {
+        (c as any)[entries[i].k] = entries[i].v;
+    }
+
+    if (!cs) {
+        cs = [new SafeWeakRef(c)];
+        composites.safeSet(hash, cs);
+    } else if (emptyIndex === -1) {
+        cs[cs.length] = new SafeWeakRef(c);
+    } else {
+        cs[emptyIndex] = new SafeWeakRef(c);
     }
 
     register(c, hash);
@@ -128,21 +129,15 @@ export function isComposite(arg: unknown): arg is Composite {
 }
 Composite.isComposite = isComposite;
 
-function compositesStructurallyEqual(a: Composite, b: Composite, bKeys: readonly string[]): boolean {
+function compositeMatchesEntries(a: Composite, entries: readonly Entry[]): boolean {
     const aKeys = ownKeys(a);
-    if (aKeys.length !== bKeys.length) {
+    DEV: assert(isStringArray(aKeys));
+    if (aKeys.length !== entries.length) {
         return false;
     }
-    for (let i = 0; i < aKeys.length; i++) {
-        if (aKeys[i] !== bKeys[i]) {
-            return false;
-        }
-    }
-    for (let i = 0; i < aKeys.length; i++) {
-        const k = aKeys[i];
-        const aV = (a as any)[k];
-        const bV = (b as any)[k];
-        if (!is(aV, bV)) return false;
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        if (!(entry.k in a) || !is((a as any)[entry.k], entry.v)) return false;
     }
 
     return true;

--- a/polyfill/composite.ts
+++ b/polyfill/composite.ts
@@ -133,7 +133,8 @@ Composite.isComposite = isComposite;
 function compositeMatchesEntries(a: Composite, entries: readonly Entry[]): boolean {
     for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
-        if (!(entry.k in a) || !is((a as any)[entry.k], entry.v)) return false;
+        const current = (a as any)[entry.k];
+        if (!is(current, entry.v) || (current === undefined && !(entry.k in a))) return false;
     }
 
     return true;

--- a/polyfill/internal/murmur.ts
+++ b/polyfill/internal/murmur.ts
@@ -41,21 +41,49 @@ export class MurmurHashStream implements Hasher {
         }
     }
 
+    private _writeUint32(word: number): void {
+        if (this.carryBytes === 0) {
+            this._mix(word >>> 0);
+            this.length += 4;
+            return;
+        }
+        if (this.carryBytes === 2) {
+            this._mix((this.carry | (word << 16)) >>> 0);
+            this.carry = word >>> 16;
+            this.length += 4;
+            return;
+        }
+        this._writeByte(word & 0xff);
+        this._writeByte((word >>> 8) & 0xff);
+        this._writeByte((word >>> 16) & 0xff);
+        this._writeByte((word >>> 24) & 0xff);
+    }
+
     update(chunk: string | number | bigint): void {
         switch (typeof chunk) {
             case "string":
                 this.update(STRING_MARKER);
-                for (let i = 0; i < chunk.length; i++) {
+                let i = 0;
+                if (this.carryBytes === 2 && i < chunk.length) {
+                    const code = strCharCodeAt(chunk, i);
+                    this._writeByte(code & 0xff);
+                    this._writeByte((code >>> 8) & 0xff);
+                    i++;
+                }
+                if (this.carryBytes === 0) {
+                    for (; i + 1 < chunk.length; i += 2) {
+                        this._mix((strCharCodeAt(chunk, i) | (strCharCodeAt(chunk, i + 1) << 16)) >>> 0);
+                        this.length += 4;
+                    }
+                }
+                for (; i < chunk.length; i++) {
                     const code = strCharCodeAt(chunk, i);
                     this._writeByte(code & 0xff);
                     this._writeByte((code >>> 8) & 0xff);
                 }
                 return;
             case "number":
-                this._writeByte(chunk & 0xff);
-                this._writeByte((chunk >>> 8) & 0xff);
-                this._writeByte((chunk >>> 16) & 0xff);
-                this._writeByte((chunk >>> 24) & 0xff);
+                this._writeUint32(chunk);
                 return;
             case "bigint": {
                 let value = chunk;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
         "verbatimModuleSyntax": true,
         "noEmit": true
     },
-    "include": ["polyfill/**/*.ts"]
+    "include": ["polyfill/**/*.ts", "benchmarks/**/*.ts"]
 }


### PR DESCRIPTION
3 main optimizations here:
- avoiding composite throwaway allocation on cache hits. This requires 2 traversals on cache hits but I have not observed this to add up a significant amount of time to. At times I've seen a small (up to 5%~) downtick in the benchmarked cache hit scenario. 
- hashing strings in larger chunks, which reduces loop and method call overhead
- avoiding key enumeration during lookup - by storing the `.size` known upfront

| Benchmark | Before (ops/s) | After (ops/s) | Change |
|---|---:|---:|---:|
| Composite cache hit — 2 keys | 1,318,157 | 2,283,717 | **+73.3%** |
| Composite cache hit — 20 keys | 170,209 | 329,306 | **+93.5%** |
| Nested composite cache hit | 1,081,173 | 1,989,532 | **+84.0%** |
| Composite cache miss — unique number | 548,052 | 544,231 | **−0.7%** |
| Composite cache hit — 16 KiB string | 5,384 | 12,692 | **+135.7%** |

Results are seven-sample medians measured with Node.js 24.3.0.
